### PR TITLE
Feat/48 datetime bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/Blazor.PersianDatePicker.svg?style=flat)](https://www.nuget.org/packages/Blazor.PersianDatePicker/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://raw.githubusercontent.com/farshaddavoudi/Blazor.PersianDatePicker/master/LICENSE)
 
-> **Enjoying Blazor.PersianDatePicker? Please star the repository.** Stars show that the community values a modern, dependency-free Persian date picker and help us prioritize future improvements.
+> ⭐️ If Blazor.PersianDatePicker helps your project, a quick star keeps the component visible and fuels future improvements.
 
 <img src="https://github.com/fericode/Blazor.PersianDatePicker/blob/master/screenshot.png">
 
@@ -42,6 +42,7 @@ It is compatible and installable on all .NET 5, .NET 6, .NET 7, .NET 8 and .NET 
 
        // Bind input value to local variable or dto etc
        @bind-Value="_myComponentField"
+       // Optional typed binds can be used at the same time: @bind-ValueAsDateTime / @bind-ValueAsDateOnly
 
        // Html input element name attribute
        Name="myInputName" //Optional

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ In addition to the classic string binding, you can keep your view models strongl
 }
 ```
 
-Mix and match string and typed bindings in the same form depending on how you want to store dates in your domain model. You can even keep all three binds (`@bind-Value`, `@bind-ValueAsDateTime`, `@bind-ValueAsDateOnly`) on the same component. The picker keeps them synchronized, propagating whichever value changes across the other two.
+Mix and match string and typed bindings in the same form depending on how you want to store dates in your domain model. 
+
+> #### 💡 You can even keep all three binds (`@bind-Value`, `@bind-ValueAsDateTime`, `@bind-ValueAsDateOnly`) on the same component. The picker keeps them synchronized, propagating whichever value changes across the other two.
 
 ## Digit Type Configuration
 Using `InputDigitType` and `PickerDigitType` you can decouple the numerals rendered in the textbox from those rendered inside the popup. The default (`DigitType.BasedOnCalendar`) continues to follow the active Jalali/Miladi calendar, but you can now force English or Persian digits explicitly.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ It is compatible and installable on all .NET 5, .NET 6, .NET 7, .NET 8 and .NET 
        Id="myInputDatePicker" //Optional
 
        // Bind input value to local variable or dto etc
-       @bind-Value="_myComponentField"
-       // Optional typed binds can be used at the same time: @bind-ValueAsDateTime / @bind-ValueAsDateOnly
+       @bind-Value="_stringVar"
+       // Optional typed binds can be used at the same time: 
+       // @bind-ValueAsDateTime="_dateTimeVar"
+       // @bind-ValueAsDateOnly="_dateOnlyVar"
 
        // Html input element name attribute
        Name="myInputName" //Optional
@@ -142,7 +144,7 @@ In addition to the classic string binding, you can keep your view models strongl
 }
 ```
 
-Mix and match string and typed bindings in the same form depending on how you want to store dates in your domain model.
+Mix and match string and typed bindings in the same form depending on how you want to store dates in your domain model. You can even keep all three binds (`@bind-Value`, `@bind-ValueAsDateTime`, `@bind-ValueAsDateOnly`) on the same component. The picker keeps them synchronized, propagating whichever value changes across the other two.
 
 ## Digit Type Configuration
 Using `InputDigitType` and `PickerDigitType` you can decouple the numerals rendered in the textbox from those rendered inside the popup. The default (`DigitType.BasedOnCalendar`) continues to follow the active Jalali/Miladi calendar, but you can now force English or Persian digits explicitly.
@@ -199,5 +201,6 @@ Using `InputDigitType` and `PickerDigitType` you can decouple the numerals rende
 
 ## Special Thanks:
   *This project was originally ported from [pwt.datepicker](https://github.com/babakhani/pwt.datepicker), a jQuery-based datepicker that is now officially deprecated. We're grateful to Reza Babakhani @babakhani and every contributor whose work laid the groundwork for this modern Blazor alternative.*
+
 
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![NuGet Version](https://img.shields.io/nuget/v/Blazor.PersianDatePicker.svg?style=flat)](https://www.nuget.org/packages/Blazor.PersianDatePicker/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://raw.githubusercontent.com/farshaddavoudi/Blazor.PersianDatePicker/master/LICENSE)
 
+> **Enjoying Blazor.PersianDatePicker? Please star the repository.** Stars show that the community values a modern, dependency-free Persian date picker and help us prioritize future improvements.
+
 <img src="https://github.com/fericode/Blazor.PersianDatePicker/blob/master/screenshot.png">
 
 ##### 🎈 Optimize design after `v2.0.0` | Mark holidays (optional) after `v3.5.0` — Thanks to [@Mostafa-Moradi](https://github.com/Mostafa-Moradi) for asking [the feature](https://github.com/farshaddavoudi/Blazor.PersianDatePicker/issues/93)
@@ -118,6 +120,29 @@ It is compatible and installable on all .NET 5, .NET 6, .NET 7, .NET 8 and .NET 
 
 ```
 
+### Bind to `DateTime` / `DateOnly`
+
+In addition to the classic string binding, you can keep your view models strongly typed:
+
+```razor
+<InputPersianDatePicker Id="orderDatePicker"
+                        @bind-ValueAsDateTime="OrderDate"
+                        CalendarType="Calendar.DualModeMiladiDefault" />
+
+<InputPersianDatePicker Id="deadlinePicker"
+                        @bind-ValueAsDateOnly="Deadline"
+                        CalendarType="Calendar.SingleModeJalali" />
+```
+
+```csharp
+@code {
+    private DateTime? OrderDate { get; set; }
+    private DateOnly? Deadline { get; set; }
+}
+```
+
+Mix and match string and typed bindings in the same form depending on how you want to store dates in your domain model.
+
 ## Digit Type Configuration
 Using `InputDigitType` and `PickerDigitType` you can decouple the numerals rendered in the textbox from those rendered inside the popup. The default (`DigitType.BasedOnCalendar`) continues to follow the active Jalali/Miladi calendar, but you can now force English or Persian digits explicitly.
 
@@ -172,5 +197,6 @@ Using `InputDigitType` and `PickerDigitType` you can decouple the numerals rende
 
 
 ## Special Thanks:
-  *This project is ported from [pwt.datepicker](https://github.com/babakhani/pwt.datepicker) project with a lot of customizations and optimizations for easy and fast use for Blazor applications. Therefore, I appreciate the great effort of Reza Babakhani @babakhani and all contributors of that project*
+  *This project was originally ported from [pwt.datepicker](https://github.com/babakhani/pwt.datepicker), a jQuery-based datepicker that is now officially deprecated. We're grateful to Reza Babakhani @babakhani and every contributor whose work laid the groundwork for this modern Blazor alternative.*
+
 

--- a/samples/BlazorServer/Pages/Index.razor
+++ b/samples/BlazorServer/Pages/Index.razor
@@ -6,106 +6,142 @@
 
 <SurveyPrompt Title="How is Blazor working for you?" />
 
-<InputPersianDatePicker Id="myInputDatePicker"
-                        @bind-Value="_variable1"
-                        Name="myInputName"
-                        Visible="true"
-                        ReadOnly="false"
-                        PickerAlign="Align.Right"
-                        PickerOffsetTopPositionInPixels="0"
-                        InitialValueSetOnToday="true"
-                        ShowCalendarIcon="true"
-                        CalendarType="Calendar.DualModeJalaliDefault"
-                        InputDigitType="DigitType.English"
-                        PickerDigitType="DigitType.Persian"
-                        DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
-                        MinDateSetOnToday="true"
-                        Placeholder="Select date"
-                        CssClass="form-control"
-                        Style="margin-left:20px;
-        width: 20%;
-        float: right"
-                        Theme="PickerTheme.Default"
-                        OnChange="@(() => Console.WriteLine($"OK1 - {_variable1}"))"
-                        OnClear="@(() => Console.WriteLine("Clear1"))" />
-
-<InputPersianDatePicker Id="myInputDatePicker2"
-                        @bind-Value="_variable2"
-                        Name="myInputName"
-                        Visible="true"
-                        Disabled="true"
-                        PickerAlign="Align.Left"
-                        ShowCalendarIcon="false"
-                        PickerOffsetTopPositionInPixels="25"
-                        InitialValueSetOnToday="false"
-                        CalendarType="Calendar.DualModeMiladiDefault"
-                        InputDigitType="DigitType.BasedOnCalendar"
-                        DateFormat="DateFormat.yyyy_dash_MM_dash_dd"
-                        MinDateSetOnToday="true"
-                        Placeholder="Disabled input"
-                        CssClass="form-control"
-                        Style="border: 1px solid purple;
-        margin-left:20px;
-        width: 20%;
-        float: right"
-                        Theme="PickerTheme.Blue"
-                        OnChange="@(() => Console.WriteLine($"OK2 - {_variable2}"))" />
-
-
-<EditForm Model="Book">
-
-    <InputPersianDatePicker Id="myInputDatePicker3"
-                            @bind-Value="_variable3"
+<div style="display: flex; flex-direction: row-reverse; justify-content: space-around; padding: 50px;">
+    <InputPersianDatePicker Id="myInputDatePicker"
+                            @bind-Value="_variable1"
                             Name="myInputName"
                             Visible="true"
-                            ShowCalendarIcon="false"
+                            ReadOnly="false"
                             PickerAlign="Align.Right"
                             PickerOffsetTopPositionInPixels="0"
+                            InitialValueSetOnToday="true"
+                            ShowCalendarIcon="true"
+                            CalendarType="Calendar.DualModeJalaliDefault"
+                            InputDigitType="DigitType.English"
+                            PickerDigitType="DigitType.English"
+                            DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
+                            MinDateSetOnToday="true"
+                            Placeholder="Select date"
+                            CssClass="form-control"
+                            Style="margin-left:20px;
+        width: 250px;
+        float: right;
+        border:1px solid #0d6efd"
+                            Theme="PickerTheme.Default"
+                            OnChange="@(() => Console.WriteLine($"OK1 - {_variable1}"))"
+                            OnClear="@(() => Console.WriteLine("Clear1"))" />
+
+    <InputPersianDatePicker Id="myInputDatePicker2"
+                            @bind-Value="_variable2"
+                            Name="myInputName"
+                            Visible="true"
+                            Disabled="true"
+                            PickerAlign="Align.Left"
+                            ShowCalendarIcon="false"
+                            PickerOffsetTopPositionInPixels="25"
                             InitialValueSetOnToday="false"
-                            CalendarType="Calendar.SingleModeJalali"
+                            CalendarType="Calendar.DualModeMiladiDefault"
+                            InputDigitType="DigitType.BasedOnCalendar"
+                            DateFormat="DateFormat.yyyy_dash_MM_dash_dd"
+                            MinDateSetOnToday="true"
+                            Placeholder="Disabled input"
+                            CssClass="form-control"
+                            Style="border: 1px solid purple;
+        margin-left:20px;
+        width: 250px;
+        float: right"
+                            Theme="PickerTheme.Blue"
+                            OnChange="@(() => Console.WriteLine($"OK2 - {_variable2}"))" />
+
+
+    <EditForm Model="Book">
+
+        <InputPersianDatePicker Id="myInputDatePicker3"
+                                @bind-Value="_variable3"
+                                Name="myInputName"
+                                Visible="true"
+                                ShowCalendarIcon="false"
+                                PickerAlign="Align.Right"
+                                PickerOffsetTopPositionInPixels="0"
+                                InitialValueSetOnToday="false"
+                                CalendarType="Calendar.SingleModeJalali"
+                                InputDigitType="DigitType.BasedOnCalendar"
+                                PickerDigitType="DigitType.BasedOnCalendar"
+                                DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
+                                MinDateSetOnToday="true"
+                                Placeholder="?????? ?????"
+                                CssClass="form-control"
+                                Style="text-align: right;
+                                   border: 1px solid blue;
+                                   margin-left: 20px;
+                                   width: 250px;
+                                   float: right"
+                                Theme="PickerTheme.Cheerup"
+                                OnChange="@(() => Console.WriteLine($"OK3 - {_variable3}"))" />
+
+    </EditForm>
+
+
+    <InputPersianDatePicker Id="myInputDatePicker4"
+                            @bind-Value="_variable4"
+                            Name="myInputName"
+                            Visible="true"
+                            Disabled="false"
+                            PickerAlign="Align.Right"
+                            PickerOffsetTopPositionInPixels="1"
+                            InitialValueSetOnToday="false"
+                            CalendarType="Calendar.SingleModeMiladi"
                             InputDigitType="DigitType.BasedOnCalendar"
                             DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
                             MinDateSetOnToday="true"
-                            Placeholder="انتخاب تاریخ"
+                            Placeholder="Select date"
                             CssClass="form-control"
-                            Style="text-align: right;
-                                   border: 1px solid blue;
-                                   margin-left: 20px;
-                                   width: 20%;
-                                   float: right"
-                            Theme="PickerTheme.Cheerup"
-                            OnChange="@(() => Console.WriteLine($"OK3 - {_variable3}"))" />
+                            Style="border:1px solid green; width:250px; float:right"
+                            Theme="PickerTheme.RedBlack"
+                            OnChange="@(() => Console.WriteLine($"OK4 - {_variable4}"))" />
 
-</EditForm>
+    <InputPersianDatePicker Id="myInputDatePicker5"
+                            @bind-ValueAsDateTime="_variableDateTime"
+                            Name="myDateTime"
+                            Visible="true"
+                            ReadOnly="false"
+                            PickerAlign="Align.Right"
+                            CalendarType="Calendar.DualModeMiladiDefault"
+                            InputDigitType="DigitType.English"
+                            PickerDigitType="DigitType.BasedOnCalendar"
+                            DateFormat="DateFormat.yyyy_dash_MM_dash_dd"
+                            Placeholder="Select event date"
+                            CssClass="form-control"
+                            Style="border:1px solid orange; width:250px; float:right"
+                            Theme="PickerTheme.Dark" />
 
-
-<InputPersianDatePicker Id="myInputDatePicker4"
-                        @bind-Value="_variable4"
-                        Name="myInputName"
-                        Visible="true"
-                        Disabled="false"
-                        PickerAlign="Align.Right"
-                        PickerOffsetTopPositionInPixels="1"
-                        InitialValueSetOnToday="false"
-                        CalendarType="Calendar.SingleModeMiladi"
-                        InputDigitType="DigitType.BasedOnCalendar"
-                        DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
-                        MinDateSetOnToday="true"
-                        Placeholder="Select date"
-                        CssClass="form-control"
-                        Style="border:1px solid green; width:20%; float:right"
-                        Theme="PickerTheme.RedBlack"
-                        OnChange="@(() => Console.WriteLine($"OK4 - {_variable4}"))" />
+    <InputPersianDatePicker Id="myInputDatePicker6"
+                            @bind-ValueAsDateOnly="_variableDateOnly"
+                            Name="myDateOnly"
+                            Visible="true"
+                            ReadOnly="false"
+                            PickerAlign="Align.Right"
+                            CalendarType="Calendar.SingleModeMiladi"
+                            InputDigitType="DigitType.BasedOnCalendar"
+                            DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
+                            InitialValueSetOnToday="true"
+                            Placeholder="Select deadline"
+                            CssClass="form-control"
+                            Style="border:1px solid #8a2be2; width:250px; float:right"
+                            Theme="PickerTheme.Blue" />
+</div>
 
 <br />
 <br />
 <br />
 
-<div style="display: flex; flex-direction: row-reverse; border: 1px solid green;justify-content: space-around; padding: 50px">
-    <b> Val1= @_variable1 </b>
-    <b> Val2= @_variable2 </b>
-    <b> Val3= @_variable3 </b>
-    <b> Val4= @_variable4 </b>
+<div style="display: flex; flex-direction: row-reverse; border: 1px solid #ccc;justify-content: space-around; padding: 50px">
+    <b style="color: #0d6efd;"> Val1= @_variable1 </b>
+    <b style="color: purple;"> Val2= @_variable2 </b>
+    <b style="color: blue;"> Val3= @_variable3 </b>
+    <b style="color: green;"> Val4= @_variable4 </b>
+    <b style="color: orange;"> Val5 DateTime= @(_variableDateTime?.ToString("u") ?? "null") </b>
+    <b style="color: #8a2be2;"> Val6 DateOnly= @(_variableDateOnly?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) ?? "null") </b>
 </div>
 
 @*<label style="float: right; font-size: 25px; font-weight:bold"> @_myComponentPrivateField </label>*@
@@ -116,11 +152,13 @@
     private string _variable2;
     private string _variable3;
     private string _variable4;
+    private DateTime? _variableDateTime;
+    private DateOnly? _variableDateOnly;
     private BookModel Book { get; set; } = new();
 
     protected override void OnInitialized()
     {
-        _variable3 = "۱۴۰۲/۱۱/۱۱";
+        _variable3 = "۱۴۰۴/۰۴/۱۱";
 
         base.OnInitialized();
     }
@@ -130,4 +168,6 @@
         public string Name { get; set; }
     }
 }
+
+
 

--- a/samples/BlazorWebAssembly/Pages/Index.razor
+++ b/samples/BlazorWebAssembly/Pages/Index.razor
@@ -6,108 +6,143 @@
 
 <SurveyPrompt Title="How is Blazor working for you?" />
 
-<InputPersianDatePicker Id="myInputDatePicker"
-                        @bind-Value="_variable1"
-                        Name="myInputName"
-                        Visible="true"
-                        ReadOnly="false"
-                        PickerAlign="Align.Right"
-                        PickerOffsetTopPositionInPixels="0"
-                        InitialValueSetOnToday="true"
-                        ShowCalendarIcon="true"
-                        CalendarType="Calendar.DualModeJalaliDefault"
-                        InputDigitType="DigitType.English"
-                        PickerDigitType="DigitType.English"
-                        DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
-                        MinDateSetOnToday="true"
-                        Placeholder="Select date"
-                        CssClass="form-control"
-                        Style="margin-left:20px;
-        width: 20%;
-        float: right"
-                        Theme="PickerTheme.Default"
-                        MarkedDates="_markedDays"
-                        OnChange="@(() => Console.WriteLine($"OK1 - {_variable1}"))"
-                        OnClear="@(() => Console.WriteLine("Clear1"))" />
-
-<InputPersianDatePicker Id="myInputDatePicker2"
-                        @bind-Value="_variable2"
-                        Name="myInputName"
-                        Visible="true"
-                        Disabled="true"
-                        PickerAlign="Align.Left"
-                        ShowCalendarIcon="false"
-                        PickerOffsetTopPositionInPixels="25"
-                        InitialValueSetOnToday="false"
-                        CalendarType="Calendar.DualModeMiladiDefault"
-                        InputDigitType="DigitType.BasedOnCalendar"
-                        DateFormat="DateFormat.yyyy_dash_MM_dash_dd"
-                        MinDateSetOnToday="true"
-                        Placeholder="Disabled input"
-                        CssClass="form-control"
-                        Style="border: 1px solid purple;
-        margin-left:20px;
-        width: 20%;
-        float: right"
-                        Theme="PickerTheme.Blue"
-                        OnChange="@(() => Console.WriteLine($"OK2 - {_variable2}"))" />
-
-
-<EditForm Model="Book">
-
-    <InputPersianDatePicker Id="myInputDatePicker3"
-                            @bind-Value="_variable3"
+<div style="display: flex; flex-direction: row-reverse; justify-content: space-around; padding: 50px;">
+    <InputPersianDatePicker Id="myInputDatePicker"
+                            @bind-Value="_variable1"
                             Name="myInputName"
                             Visible="true"
-                            ShowCalendarIcon="false"
+                            ReadOnly="false"
                             PickerAlign="Align.Right"
                             PickerOffsetTopPositionInPixels="0"
-                            InitialValueSetOnToday="false"
-                            CalendarType="Calendar.SingleModeJalali"
-                            InputDigitType="DigitType.BasedOnCalendar"
-                            PickerDigitType="DigitType.BasedOnCalendar"
+                            InitialValueSetOnToday="true"
+                            ShowCalendarIcon="true"
+                            CalendarType="Calendar.DualModeJalaliDefault"
+                            InputDigitType="DigitType.English"
+                            PickerDigitType="DigitType.English"
                             DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
                             MinDateSetOnToday="true"
-                            Placeholder="انتخاب تاریخ"
+                            Placeholder="Select date"
                             CssClass="form-control"
-                            Style="text-align: right;      
+                            Style="margin-left:20px;
+        width: 250px;
+        float: right;
+        border:1px solid #0d6efd"
+                            Theme="PickerTheme.Default"
+                            MarkedDates="_markedDays"
+                            OnChange="@(() => Console.WriteLine($"OK1 - {_variable1}"))"
+                            OnClear="@(() => Console.WriteLine("Clear1"))" />
+
+    <InputPersianDatePicker Id="myInputDatePicker2"
+                            @bind-Value="_variable2"
+                            Name="myInputName"
+                            Visible="true"
+                            Disabled="true"
+                            PickerAlign="Align.Left"
+                            ShowCalendarIcon="false"
+                            PickerOffsetTopPositionInPixels="25"
+                            InitialValueSetOnToday="false"
+                            CalendarType="Calendar.DualModeMiladiDefault"
+                            InputDigitType="DigitType.BasedOnCalendar"
+                            DateFormat="DateFormat.yyyy_dash_MM_dash_dd"
+                            MinDateSetOnToday="true"
+                            Placeholder="Disabled input"
+                            CssClass="form-control"
+                            Style="border: 1px solid purple;
+        margin-left:20px;
+        width: 250px;
+        float: right"
+                            Theme="PickerTheme.Blue"
+                            OnChange="@(() => Console.WriteLine($"OK2 - {_variable2}"))" />
+
+
+    <EditForm Model="Book">
+
+        <InputPersianDatePicker Id="myInputDatePicker3"
+                                @bind-Value="_variable3"
+                                Name="myInputName"
+                                Visible="true"
+                                ShowCalendarIcon="false"
+                                PickerAlign="Align.Right"
+                                PickerOffsetTopPositionInPixels="0"
+                                InitialValueSetOnToday="false"
+                                CalendarType="Calendar.SingleModeJalali"
+                                InputDigitType="DigitType.BasedOnCalendar"
+                                PickerDigitType="DigitType.BasedOnCalendar"
+                                DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
+                                MinDateSetOnToday="true"
+                                Placeholder="انتخاب تاریخ"
+                                CssClass="form-control"
+                                Style="text-align: right;
                                    border: 1px solid blue;
                                    margin-left: 20px;
-                                   width: 20%;
+                                   width: 250px;
                                    float: right"
-                            Theme="PickerTheme.Cheerup"
-                            OnChange="@(() => Console.WriteLine($"OK3 - {_variable3}"))" />
+                                Theme="PickerTheme.Cheerup"
+                                OnChange="@(() => Console.WriteLine($"OK3 - {_variable3}"))" />
 
-</EditForm>
+    </EditForm>
 
 
-<InputPersianDatePicker Id="myInputDatePicker4"
-                        @bind-Value="_variable4"
-                        Name="myInputName"
-                        Visible="true"
-                        Disabled="false"
-                        PickerAlign="Align.Right"
-                        PickerOffsetTopPositionInPixels="1"
-                        InitialValueSetOnToday="false"
-                        CalendarType="Calendar.SingleModeMiladi"
-                        InputDigitType="DigitType.BasedOnCalendar"
-                        DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
-                        MinDateSetOnToday="true"
-                        Placeholder="Select date"
-                        CssClass="form-control"
-                        Style="border:1px solid green; width:20%; float:right"
-                        Theme="PickerTheme.RedBlack"
-                        OnChange="@(() => Console.WriteLine($"OK4 - {_variable4}"))" />
-                        
+    <InputPersianDatePicker Id="myInputDatePicker4"
+                            @bind-Value="_variable4"
+                            Name="myInputName"
+                            Visible="true"
+                            Disabled="false"
+                            PickerAlign="Align.Right"
+                            PickerOffsetTopPositionInPixels="1"
+                            InitialValueSetOnToday="false"
+                            CalendarType="Calendar.SingleModeMiladi"
+                            InputDigitType="DigitType.BasedOnCalendar"
+                            DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
+                            MinDateSetOnToday="true"
+                            Placeholder="Select date"
+                            CssClass="form-control"
+                            Style="border:1px solid green; width:250px; float:right"
+                            Theme="PickerTheme.RedBlack"
+                            OnChange="@(() => Console.WriteLine($"OK4 - {_variable4}"))" />
+
+    <InputPersianDatePicker Id="myInputDatePicker5"
+                            @bind-ValueAsDateTime="_variableDateTime"
+                            Name="myDateTime"
+                            Visible="true"
+                            ReadOnly="false"
+                            PickerAlign="Align.Right"
+                            CalendarType="Calendar.DualModeMiladiDefault"
+                            InputDigitType="DigitType.English"
+                            PickerDigitType="DigitType.BasedOnCalendar"
+                            DateFormat="DateFormat.yyyy_dash_MM_dash_dd"
+                            Placeholder="Select event date"
+                            CssClass="form-control"
+                            Style="border:1px solid orange; width:250px; float:right"
+                            Theme="PickerTheme.Dark" />
+
+    <InputPersianDatePicker Id="myInputDatePicker6"
+                            @bind-ValueAsDateOnly="_variableDateOnly"
+                            Name="myDateOnly"
+                            Visible="true"
+                            ReadOnly="false"
+                            PickerAlign="Align.Right"
+                            CalendarType="Calendar.SingleModeMiladi"
+                            InputDigitType="DigitType.BasedOnCalendar"
+                            DateFormat="DateFormat.yyyy_slash_MM_slash_dd"
+                            InitialValueSetOnToday="true"
+                            Placeholder="Select deadline"
+                            CssClass="form-control"
+                            Style="border:1px solid #8a2be2; width:250px; float:right"
+                            Theme="PickerTheme.Blue" />
+</div>
+
 <br />
 <br />
 <br />
 
-<div style="display: flex; flex-direction: row-reverse; border: 1px solid green;justify-content: space-around; padding: 50px">
-    <b> Val1= @_variable1 </b>
-    <b> Val2= @_variable2 </b>
-    <b> Val3= @_variable3 </b>
-    <b> Val4= @_variable4 </b>
+<div style="display: flex; flex-direction: row-reverse; border: 1px solid #ccc; justify-content: space-around; padding: 50px">
+    <b style="color: #0d6efd;"> Val1= @_variable1 </b>
+    <b style="color: purple;"> Val2= @_variable2 </b>
+    <b style="color: blue;"> Val3= @_variable3 </b>
+    <b style="color: green;"> Val4= @_variable4 </b>
+    <b style="color: orange;"> Val5 DateTime= @(_variableDateTime?.ToString("u") ?? "null") </b>
+    <b style="color: #8a2be2;"> Val6 DateOnly= @(_variableDateOnly?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) ?? "null") </b>
 </div>
 
 @*<label style="float: right; font-size: 25px; font-weight:bold"> @_myComponentPrivateField </label>*@
@@ -118,13 +153,15 @@
     private string _variable2;
     private string _variable3;
     private string _variable4;
+    private DateTime? _variableDateTime;
+    private DateOnly? _variableDateOnly;
     private BookModel Book { get; set; } = new();
 
     private List<string> _markedDays = new() { "1403-06-25", "1403/06/27", "1403/06/28" };
 
     protected override void OnInitialized()
     {
-        _variable3 = "۱۴۰۲/۱۱/۱۱";
+        _variable3 = "۱۴۰۴/۰۴/۱۱";
 
         base.OnInitialized();
     }

--- a/src/Blazor.PersianDatePicker/InputPersianDatePicker.razor
+++ b/src/Blazor.PersianDatePicker/InputPersianDatePicker.razor
@@ -42,6 +42,15 @@
     public FieldIdentifier FieldIdentifier { get; private set; }
 
     private string? _value;
+    private DateTime? _valueAsDateTime;
+    private DateOnly? _valueAsDateOnly;
+    private bool _isSyncingFromString;
+    private bool _isSyncingFromDateTime;
+    private bool _isSyncingFromDateOnly;
+    private FieldIdentifier? _stringFieldIdentifier;
+    private FieldIdentifier? _dateTimeFieldIdentifier;
+    private FieldIdentifier? _dateOnlyFieldIdentifier;
+    private EditContext? _lastEditContext;
     private bool _isJalaliCurrentCalendarType;
     private DigitType _inputDigitType = DigitType.BasedOnCalendar;
 
@@ -54,12 +63,55 @@
         get => _value;
         set
         {
-            if (!EqualityComparer<string>.Default.Equals(value, _value))
+            if (!EqualityComparer<string?>.Default.Equals(value, _value))
             {
                 _value = value;
+
+                if (!_isSyncingFromDateTime && !_isSyncingFromDateOnly)
+                {
+                    UpdateTypedValuesFromString(value);
+                }
             }
         }
     }
+
+    [Parameter]
+    public DateTime? ValueAsDateTime
+    {
+        get => _valueAsDateTime;
+        set
+        {
+            if (!EqualityComparer<DateTime?>.Default.Equals(value, _valueAsDateTime))
+            {
+                UpdateFromDateTime(value, true);
+            }
+        }
+    }
+
+    [Parameter]
+    public EventCallback<DateTime?> ValueAsDateTimeChanged { get; set; }
+
+    [Parameter]
+    public Expression<Func<DateTime?>>? ValueAsDateTimeExpression { get; set; }
+
+    [Parameter]
+    public DateOnly? ValueAsDateOnly
+    {
+        get => _valueAsDateOnly;
+        set
+        {
+            if (!EqualityComparer<DateOnly?>.Default.Equals(value, _valueAsDateOnly))
+            {
+                UpdateFromDateOnly(value, true);
+            }
+        }
+    }
+
+    [Parameter]
+    public EventCallback<DateOnly?> ValueAsDateOnlyChanged { get; set; }
+
+    [Parameter]
+    public Expression<Func<DateOnly?>>? ValueAsDateOnlyExpression { get; set; }
 
     [Parameter]
     public EventCallback<string> ValueChanged { get; set; }
@@ -256,11 +308,7 @@
         {
             var dt = DateTime.Now;
 
-            _value = _isJalaliCurrentCalendarType
-                ? GetPersianDateFromGregorianDate(dt)
-                : dt.ToString(DateFormat.GetCSharpFormat());
-
-            ModifyValueDigit();
+            UpdateFromDateTime(dt, true);
 
             await OnValueChanged();
         }
@@ -276,10 +324,65 @@
     {
         var result = base.SetParametersAsync(parameters);
 
-        if (EditContext != null && ValueExpression != null && FieldIdentifier.Model != EditContext.Model)
+        if (EditContext != null)
         {
-            FieldIdentifier = FieldIdentifier.Create(ValueExpression);
-            EditContext.OnValidationStateChanged += ValidationStateChanged;
+            if (!ReferenceEquals(EditContext, _lastEditContext))
+            {
+                if (_lastEditContext != null)
+                {
+                    _lastEditContext.OnValidationStateChanged -= ValidationStateChanged;
+                }
+
+                EditContext.OnValidationStateChanged += ValidationStateChanged;
+                _lastEditContext = EditContext;
+            }
+
+            if (ValueExpression != null)
+            {
+                var stringField = FieldIdentifier.Create(ValueExpression);
+                _stringFieldIdentifier = stringField;
+                FieldIdentifier = stringField;
+            }
+            else
+            {
+                _stringFieldIdentifier = null;
+            }
+
+            if (ValueAsDateTimeExpression != null)
+            {
+                var dateTimeField = FieldIdentifier.Create(ValueAsDateTimeExpression);
+                _dateTimeFieldIdentifier = dateTimeField;
+                if (!_stringFieldIdentifier.HasValue)
+                {
+                    FieldIdentifier = dateTimeField;
+                }
+            }
+            else
+            {
+                _dateTimeFieldIdentifier = null;
+            }
+
+            if (ValueAsDateOnlyExpression != null)
+            {
+                var dateOnlyField = FieldIdentifier.Create(ValueAsDateOnlyExpression);
+                _dateOnlyFieldIdentifier = dateOnlyField;
+                if (!_stringFieldIdentifier.HasValue && !_dateTimeFieldIdentifier.HasValue)
+                {
+                    FieldIdentifier = dateOnlyField;
+                }
+            }
+            else
+            {
+                _dateOnlyFieldIdentifier = null;
+            }
+        }
+        else if (_lastEditContext != null)
+        {
+            _lastEditContext.OnValidationStateChanged -= ValidationStateChanged;
+            _lastEditContext = null;
+            _stringFieldIdentifier = null;
+            _dateTimeFieldIdentifier = null;
+            _dateOnlyFieldIdentifier = null;
         }
 
         return result;
@@ -337,12 +440,9 @@
     {
         Value = $"{args.Value}";
 
-        await ValueChanged.InvokeAsync(Value);
-
-        EditContext?.NotifyFieldChanged(FieldIdentifier);
-
-        await OnChange.InvokeAsync(Value);
+        await OnValueChanged();
     }
+
 
     [JSInvokable]
     public async Task SetDate(long? timestamp, string elementId, bool switchingCalendar = false)
@@ -352,40 +452,25 @@
 
         if (timestamp != null)
         {
-            var dt = new DateTime(1970, 1, 1, 0, 0, 0, 0)
-                .AddSeconds(Math.Round((long)timestamp / 1000d)).ToLocalTime();
-
-            _value = _isJalaliCurrentCalendarType
-                ? GetPersianDateFromGregorianDate(dt)
-                : dt.ToString(DateFormat.GetCSharpFormat());
+            var dt = DateTimeOffset.FromUnixTimeMilliseconds((long)timestamp).LocalDateTime;
+            UpdateFromDateTime(dt, true);
         }
 
         if (switchingCalendar)
         {
+            var previousCalendarWasJalali = _isJalaliCurrentCalendarType;
+
             _isJalaliCurrentCalendarType = !_isJalaliCurrentCalendarType;
 
-            if (_isJalaliCurrentCalendarType)
-            {
-                // Change from en to fa: 2021/04/03 => 1400/05/02
-                var dt = Convert.ToDateTime(_value);
+            DateTime? activeDateTime = _valueAsDateTime;
 
-                _value = GetPersianDateFromGregorianDate(dt);
-            }
-            else
+            if (!activeDateTime.HasValue && TryParseComponentValue(_value, out var parsedFromValue, previousCalendarWasJalali))
             {
-                // Change from fa to en: 1400/05/05 => 2021/01/05
-                // Convert to Miladi
-                if (_value != null)
-                {
-                    DateTime dt = DateTime.Parse(_value, new CultureInfo("fa-IR"));
-
-                    // Get Date
-                    _value = dt.ToString(DateFormat.GetCSharpFormat());
-                }
+                activeDateTime = parsedFromValue;
             }
+
+            UpdateFromDateTime(activeDateTime, true);
         }
-
-        ModifyValueDigit();
 
         await OnValueChanged();
     }
@@ -395,14 +480,153 @@
     {
         var dt = DateTime.Today;
 
-        _value = _isJalaliCurrentCalendarType
-            ? GetPersianDateFromGregorianDate(dt)
-            : dt.ToString(DateFormat.GetCSharpFormat());
-
-        ModifyValueDigit();
+        UpdateFromDateTime(dt, true);
 
         await OnValueChanged();
     }
+
+    private void UpdateFromDateTime(DateTime? dateTime, bool updateString)
+    {
+        _isSyncingFromDateTime = true;
+
+        _valueAsDateTime = dateTime;
+        _valueAsDateOnly = dateTime.HasValue ? DateOnly.FromDateTime(dateTime.Value) : null;
+
+        if (updateString)
+        {
+            _value = FormatValueFromDateTime(dateTime);
+            ModifyValueDigit();
+        }
+
+        _isSyncingFromDateTime = false;
+    }
+
+    private void UpdateFromDateOnly(DateOnly? dateOnly, bool updateString)
+    {
+        _isSyncingFromDateOnly = true;
+
+        _valueAsDateOnly = dateOnly;
+
+        DateTime? dateTime = dateOnly?.ToDateTime(TimeOnly.MinValue);
+
+        UpdateFromDateTime(dateTime, updateString);
+
+        _isSyncingFromDateOnly = false;
+    }
+
+    private void UpdateTypedValuesFromString(string? value)
+    {
+        if (_isSyncingFromString)
+        {
+            return;
+        }
+
+        _isSyncingFromString = true;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            UpdateFromDateTime(null, false);
+            _isSyncingFromString = false;
+            return;
+        }
+
+        if (TryParseComponentValue(value, out var parsedDate))
+        {
+            UpdateFromDateTime(parsedDate, false);
+        }
+
+        _isSyncingFromString = false;
+    }
+
+    private string? FormatValueFromDateTime(DateTime? dateTime)
+    {
+        if (!dateTime.HasValue)
+        {
+            return string.Empty;
+        }
+
+        if (_isJalaliCurrentCalendarType)
+        {
+            return GetPersianDateFromGregorianDate(dateTime.Value);
+        }
+
+        var format = DateFormat.GetCSharpFormat() ?? "yyyy/MM/dd";
+        return dateTime.Value.ToString(format, CultureInfo.InvariantCulture);
+    }
+
+    private bool TryParseComponentValue(string? value, out DateTime? parsedDateTime, bool? useJalaliOverride = null)
+    {
+        parsedDateTime = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var sanitized = value.Trim().PersianToEnglishDigits();
+        sanitized = sanitized.Replace('-', '/');
+
+        var parts = sanitized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 3)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[0], out var year) ||
+            !int.TryParse(parts[1], out var month) ||
+            !int.TryParse(parts[2], out var day))
+        {
+            return false;
+        }
+
+        try
+        {
+            DateTime dateTime;
+            var useJalali = useJalaliOverride ?? _isJalaliCurrentCalendarType;
+
+            if (useJalali)
+            {
+                var persianCalendar = new PersianCalendar();
+                dateTime = persianCalendar.ToDateTime(year, month, day, 0, 0, 0, 0);
+            }
+            else
+            {
+                dateTime = new DateTime(year, month, day);
+            }
+
+            parsedDateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified);
+            return true;
+        }
+        catch
+        {
+            parsedDateTime = null;
+            return false;
+        }
+    }
+
+    private void NotifyFieldChanged()
+    {
+        if (EditContext == null)
+        {
+            return;
+        }
+
+        if (_stringFieldIdentifier.HasValue)
+        {
+            EditContext.NotifyFieldChanged(_stringFieldIdentifier.Value);
+        }
+
+        if (_dateTimeFieldIdentifier.HasValue)
+        {
+            EditContext.NotifyFieldChanged(_dateTimeFieldIdentifier.Value);
+        }
+
+        if (_dateOnlyFieldIdentifier.HasValue)
+        {
+            EditContext.NotifyFieldChanged(_dateOnlyFieldIdentifier.Value);
+        }
+    }
+
 
     private static string ToDigitTypeString(DigitType digitType)
     {
@@ -433,8 +657,10 @@
     private async Task OnValueChanged()
     {
         await ValueChanged.InvokeAsync(_value);
+        await ValueAsDateTimeChanged.InvokeAsync(_valueAsDateTime);
+        await ValueAsDateOnlyChanged.InvokeAsync(_valueAsDateOnly);
 
-        EditContext?.NotifyFieldChanged(FieldIdentifier);
+        NotifyFieldChanged();
 
         await OnChange.InvokeAsync(Value);
     }
@@ -448,9 +674,9 @@
 
     private async Task Clear()
     {
-        await ValueChanged.InvokeAsync(string.Empty);
+        Value = string.Empty;
 
-        EditContext?.NotifyFieldChanged(FieldIdentifier);
+        await OnValueChanged();
 
         await OnClear.InvokeAsync();
     }
@@ -517,9 +743,10 @@
         if (!_disposed && disposing)
         {
             // Unsubscribe from EditContext events
-            if (EditContext != null)
+            if (_lastEditContext != null)
             {
-                EditContext.OnValidationStateChanged -= ValidationStateChanged;
+                _lastEditContext.OnValidationStateChanged -= ValidationStateChanged;
+                _lastEditContext = null;
             }
 
             // Dispose DotNetObjectReference to prevent memory leaks
@@ -535,3 +762,11 @@
         }
     }
 }
+
+
+
+
+
+
+
+

--- a/src/Blazor.PersianDatePicker/wwwroot/datepicker.min.js
+++ b/src/Blazor.PersianDatePicker/wwwroot/datepicker.min.js
@@ -38,9 +38,10 @@ function blazorReady(
                 return;
             }
 
-            const activeCalendar = pickerInstance.model.options.calendarType;
-            const pickerConfig = mapDigitConfig(pickerDigitType, activeCalendar === 'persian', hasExplicitPickerDigitType);
-            const inputConfig = mapDigitConfig(inputDigitType, activeCalendar === 'persian', hasExplicitInputDigitType);
+            const activeCalendar = pickerInstance.model.options.calendar_ || pickerInstance.model.options.calendarType;
+            const isPersianCalendar = activeCalendar === 'persian';
+            const pickerConfig = mapDigitConfig(pickerDigitType, isPersianCalendar, hasExplicitPickerDigitType);
+            const inputConfig = mapDigitConfig(inputDigitType, isPersianCalendar, hasExplicitInputDigitType);
 
             let optionsChanged = false;
 


### PR DESCRIPTION
This pull request introduces significant improvements to the Blazor Persian DatePicker component, focusing on enhanced binding flexibility, demo updates, and documentation improvements. The most notable change is the addition of strongly-typed binding support for `DateTime` and `DateOnly`, allowing developers to synchronize and mix string and typed date representations seamlessly. The sample projects and documentation have been updated to demonstrate these new features and provide clearer guidance.

### Typed binding support for date values

* Added support for `@bind-ValueAsDateTime` and `@bind-ValueAsDateOnly` to the `InputPersianDatePicker` component, enabling direct binding to `DateTime?` and `DateOnly?` properties alongside classic string binding. All three binds (string, DateTime, DateOnly) are kept synchronized automatically. (`src/Blazor.PersianDatePicker/InputPersianDatePicker.razor` [[1]](diffhunk://#diff-20b833c03914d4ee6b8b29bd947e96008bbb9352fbc2bcd9784062147a6ac5b7L57-R115) [[2]](diffhunk://#diff-20b833c03914d4ee6b8b29bd947e96008bbb9352fbc2bcd9784062147a6ac5b7R45-R53) [[3]](diffhunk://#diff-20b833c03914d4ee6b8b29bd947e96008bbb9352fbc2bcd9784062147a6ac5b7L259-R311)
* Updated the README to document typed binding usage, including code samples and explanations of how string and typed binds can be mixed and synchronized. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R47) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126-R150)

### Demo and sample improvements

* Enhanced both Blazor Server and WebAssembly sample pages to showcase the new typed binding features, including additional pickers bound to `DateTime?` and `DateOnly?` properties, and improved output display for these values. (`samples/BlazorServer/Pages/Index.razor` [[1]](diffhunk://#diff-af701b50ed4eba31835d6d2b6dbe0bca3c8c9f136b1fac86a315754184c011d7L96-R144) [[2]](diffhunk://#diff-af701b50ed4eba31835d6d2b6dbe0bca3c8c9f136b1fac86a315754184c011d7R155-R161) [[3]](diffhunk://#diff-af701b50ed4eba31835d6d2b6dbe0bca3c8c9f136b1fac86a315754184c011d7R172-R173); `samples/BlazorWebAssembly/Pages/Index.razor` [[4]](diffhunk://#diff-ae6b7080c205d6ab409be722a04668a92ff7db5548c32c1e30a956fb9b363406L98-R145) [[5]](diffhunk://#diff-ae6b7080c205d6ab409be722a04668a92ff7db5548c32c1e30a956fb9b363406R156-R164)
* Updated styling and layout for sample pickers to improve clarity and consistency, with wider input fields and color-coded value displays. (`samples/BlazorServer/Pages/Index.razor` [[1]](diffhunk://#diff-af701b50ed4eba31835d6d2b6dbe0bca3c8c9f136b1fac86a315754184c011d7L20-R29) [[2]](diffhunk://#diff-af701b50ed4eba31835d6d2b6dbe0bca3c8c9f136b1fac86a315754184c011d7L49-R51) [[3]](diffhunk://#diff-af701b50ed4eba31835d6d2b6dbe0bca3c8c9f136b1fac86a315754184c011d7R69-R77); `samples/BlazorWebAssembly/Pages/Index.razor` [[4]](diffhunk://#diff-ae6b7080c205d6ab409be722a04668a92ff7db5548c32c1e30a956fb9b363406L26-R29) [[5]](diffhunk://#diff-ae6b7080c205d6ab409be722a04668a92ff7db5548c32c1e30a956fb9b363406L50-R52) [[6]](diffhunk://#diff-ae6b7080c205d6ab409be722a04668a92ff7db5548c32c1e30a956fb9b363406L76-R78)

### Documentation and messaging

* Added a prominent note in the README encouraging users to star the project to support ongoing development. (`README.md` [README.mdR6-R7](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6-R7))
* Improved the "Special Thanks" section in the README to clarify the project's origins and acknowledge contributors to the original jQuery datepicker. (`README.md` [README.mdL175-R207](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L175-R207))